### PR TITLE
[FEAT] 파티 생성 및 조회 기능 추가

### DIFF
--- a/src/main/java/com/geoparty/spring_boot/domain/member/entity/Member.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/member/entity/Member.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 public class Member extends AuditingFields {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(nullable = false)
+    @Column(nullable = false, name = "user_id")
     private Integer userId;
 
     @Setter @Column(length = 100) private String email;

--- a/src/main/java/com/geoparty/spring_boot/domain/organization/entity/Organization.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/organization/entity/Organization.java
@@ -14,4 +14,10 @@ public class Organization extends AuditingFields {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "organization_id")
     private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(length = 255)
+    private String thumbnail;
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/organization/repository/OrganizationRepository.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/organization/repository/OrganizationRepository.java
@@ -1,0 +1,7 @@
+package com.geoparty.spring_boot.domain.organization.repository;
+
+import com.geoparty.spring_boot.domain.organization.entity.Organization;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrganizationRepository extends JpaRepository<Organization, Long> {
+}

--- a/src/main/java/com/geoparty/spring_boot/domain/party/controller/PartyController.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/controller/PartyController.java
@@ -50,7 +50,15 @@ public class PartyController {
     @GetMapping
     @Operation(description = "환경단체에 따른 파티 리스트를 반환한다.")
     public ResponseEntity<List<PartyResponse>> getParties(
-            @RequestParam(name = "organization-id") final Long organizationId){
-        return ResponseEntity.status(HttpStatus.OK).body(partyService.getParties(organizationId));
+            @RequestParam(name = "organization-id", required = false) Long organizationId,
+            @RequestParam(name = "party-name", required = false) String partyName){
+
+        if (organizationId != null) {
+            // 특정 환경 단체의 파티 조회
+            return ResponseEntity.status(HttpStatus.OK).body(partyService.getPartiesByOrganization(organizationId));
+        } else {
+            // 파티 이름에 따른 파티 조회
+            return ResponseEntity.status(HttpStatus.OK).body(partyService.getPartiesByName(partyName));
+        }
     }
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/controller/PartyController.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/controller/PartyController.java
@@ -2,16 +2,16 @@ package com.geoparty.spring_boot.domain.party.controller;
 
 import com.geoparty.spring_boot.domain.member.entity.Member;
 import com.geoparty.spring_boot.domain.party.dto.request.PartyRequest;
+import com.geoparty.spring_boot.domain.party.dto.response.PartyResponse;
 import com.geoparty.spring_boot.domain.party.entity.Party;
 import com.geoparty.spring_boot.domain.party.service.PartyService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,10 +22,15 @@ public class PartyController {
 
     @PostMapping
     @Operation(description = "파티를 생성한다.") // to-do: 로그인한 유저 정보 반환하기
-    public ResponseEntity<String> createProject(@RequestBody final PartyRequest request,
+    public ResponseEntity<String> createParty(@RequestBody final PartyRequest request,
                                                 Member loginUser) {
         partyService.createParty(request, loginUser);
         return ResponseEntity.status(HttpStatus.CREATED).body("파티 생성이 완료되었습니다.");
     }
 
+    @GetMapping
+    @Operation(description = "홈화면에서 로그인한 유저의 파티 리스트를 반환한다.") // to-do: 로그인한 유저 정보 반환하기
+    public ResponseEntity<List<PartyResponse>> getParties(Member loginUser){
+        return ResponseEntity.status(HttpStatus.OK).body(partyService.getParties(loginUser));
+    }
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/controller/PartyController.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/controller/PartyController.java
@@ -1,10 +1,13 @@
 package com.geoparty.spring_boot.domain.party.controller;
 
 import com.geoparty.spring_boot.domain.member.entity.Member;
+import com.geoparty.spring_boot.domain.member.repository.MemberRepository;
 import com.geoparty.spring_boot.domain.party.dto.request.PartyRequest;
 import com.geoparty.spring_boot.domain.party.dto.response.PartyResponse;
 import com.geoparty.spring_boot.domain.party.entity.Party;
 import com.geoparty.spring_boot.domain.party.service.PartyService;
+import com.geoparty.spring_boot.global.exception.BaseException;
+import com.geoparty.spring_boot.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,18 +22,35 @@ import java.util.List;
 public class PartyController {
 
     private final PartyService partyService;
+    private final MemberRepository memberRepository;
 
     @PostMapping
     @Operation(description = "파티를 생성한다.") // to-do: 로그인한 유저 정보 반환하기
-    public ResponseEntity<String> createParty(@RequestBody final PartyRequest request,
-                                                Member loginUser) {
-        partyService.createParty(request, loginUser);
+    public ResponseEntity<String> createParty(@RequestBody final PartyRequest request) {
+        Member member = Member.builder() // 테스트용 멤버
+                .email("example@example.com")
+                .nickname("exampleNickname")
+                .userRefreshtoken("someRefreshToken")
+                .userIsWithdraw(false)
+                .socialId("socialId123")
+                .build();
+        memberRepository.save(member);
+        partyService.createParty(request, member);
         return ResponseEntity.status(HttpStatus.CREATED).body("파티 생성이 완료되었습니다.");
     }
 
     @GetMapping("/home")
     @Operation(description = "홈화면에서 로그인한 유저의 파티 리스트를 반환한다.") // to-do: 로그인한 유저 정보 반환하기
-    public ResponseEntity<List<PartyResponse>> getParties(Member loginUser){
-        return ResponseEntity.status(HttpStatus.OK).body(partyService.getParties(loginUser));
+    public ResponseEntity<List<PartyResponse>> getHomeParties(){
+        Member loginUser = memberRepository.findUserByUserId(2)
+                .orElseThrow(() -> new BaseException(ErrorCode.MEMBER_NOT_FOUND));
+        return ResponseEntity.status(HttpStatus.OK).body(partyService.getHomeParties(loginUser));
+    }
+
+    @GetMapping
+    @Operation(description = "환경단체에 따른 파티 리스트를 반환한다.")
+    public ResponseEntity<List<PartyResponse>> getParties(
+            @RequestParam(name = "organization-id") final Long organizationId){
+        return ResponseEntity.status(HttpStatus.OK).body(partyService.getParties(organizationId));
     }
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/controller/PartyController.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/controller/PartyController.java
@@ -28,7 +28,7 @@ public class PartyController {
         return ResponseEntity.status(HttpStatus.CREATED).body("파티 생성이 완료되었습니다.");
     }
 
-    @GetMapping
+    @GetMapping("/home")
     @Operation(description = "홈화면에서 로그인한 유저의 파티 리스트를 반환한다.") // to-do: 로그인한 유저 정보 반환하기
     public ResponseEntity<List<PartyResponse>> getParties(Member loginUser){
         return ResponseEntity.status(HttpStatus.OK).body(partyService.getParties(loginUser));

--- a/src/main/java/com/geoparty/spring_boot/domain/party/dto/request/PartyRequest.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/dto/request/PartyRequest.java
@@ -16,20 +16,19 @@ public class PartyRequest {
 
     private String title;
     private String intro;
-    private String imgUrl;
-    private Organization organization;
     private Integer targetPoint;
     private Integer pointPerPerson;
+    private Organization organization;
 
-    public Party toEntity(String imgUrl, Member member) {
+    public Party toEntity(Member member, Integer count) {
         return Party.builder()
+                .host(member)
                 .title(title)
                 .intro(intro)
-                .imgUrl(imgUrl)
-                .host(member)
-                .organization(organization)
                 .targetPoint(targetPoint)
                 .pointPerPerson(pointPerPerson)
+                .count(count)
+                .organization(organization)
                 .build();
     }
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/dto/request/PartyRequest.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/dto/request/PartyRequest.java
@@ -3,10 +3,8 @@ package com.geoparty.spring_boot.domain.party.dto.request;
 import com.geoparty.spring_boot.domain.member.entity.Member;
 import com.geoparty.spring_boot.domain.organization.entity.Organization;
 import com.geoparty.spring_boot.domain.party.entity.Party;
-import jakarta.persistence.Column;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import com.geoparty.spring_boot.domain.party.entity.PartyType;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,15 +16,20 @@ public class PartyRequest {
 
     private String title;
     private String intro;
-    private Member host;
+    private String imgUrl;
     private Organization organization;
+    private Integer targetPoint;
+    private Integer pointPerPerson;
 
-    public Party toEntity() {
+    public Party toEntity(String imgUrl, Member member) {
         return Party.builder()
                 .title(title)
                 .intro(intro)
-                .host(host)
+                .imgUrl(imgUrl)
+                .host(member)
                 .organization(organization)
+                .targetPoint(targetPoint)
+                .pointPerPerson(pointPerPerson)
                 .build();
     }
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/dto/response/PartyResponse.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/dto/response/PartyResponse.java
@@ -4,6 +4,7 @@ import com.geoparty.spring_boot.domain.member.entity.Member;
 import com.geoparty.spring_boot.domain.organization.entity.Organization;
 import com.geoparty.spring_boot.domain.party.entity.Party;
 import com.geoparty.spring_boot.domain.party.entity.PartyType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,25 +16,63 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class PartyResponse {
-    private String title;
+
+    @Schema(description = "후원하는 환경단체 이름")
+    private String organization;
+
+    @Schema(description = "환경단체 img url")
     private String imgUrl;
+
+    @Schema(description = "파티 이름")
+    private String title;
+
+    @Schema(description = "파티 소개")
+    private String intro;
+
+    @Schema(description = "결제 예정 날짜")
     private LocalDateTime payDate;
+
+    @Schema(description = "결제 지속 개월수")
+    private Integer duration;
+
+    @Schema(description = "목표 후원 포인트")
+    private Integer targetPoint;
+
+    @Schema(description = "실제 모인 포인트")
     private Integer totalPoint;
 
+    @Schema(description = "1인당 후원 금액")
+    private Integer pointPerPerson;
+
+    @Schema(description = "파티 상태")
+    private PartyType status;
+
     @Builder
-    public PartyResponse(String title, String imgUrl, LocalDateTime payDate, Integer totalPoint) {
-        this.title = title;
+    public PartyResponse(String organization, String imgUrl, String title, String intro, LocalDateTime payDate, Integer duration, Integer targetPoint, Integer totalPoint, Integer pointPerPerson, PartyType status) {
+        this.organization = organization;
         this.imgUrl = imgUrl;
+        this.title = title;
+        this.intro = intro;
         this.payDate = payDate;
+        this.duration = duration;
+        this.targetPoint = targetPoint;
         this.totalPoint = totalPoint;
+        this.pointPerPerson = pointPerPerson;
+        this.status = status;
     }
 
-    public static PartyResponse from(Party party){
+    public static PartyResponse from(Party party, Organization organization){
         return PartyResponse.builder()
+                .organization(organization.getTitle())
+                .imgUrl(organization.getThumbnail())
                 .title(party.getTitle())
-                .imgUrl(party.getImgUrl())
+                .intro(party.getIntro())
                 .payDate(party.getPayDate())
+                .duration(party.getDuration())
+                .targetPoint(party.getTargetPoint())
                 .totalPoint(party.getTotalPoint())
+                .pointPerPerson(party.getPointPerPerson())
+                .status(party.getStatus())
                 .build();
     }
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/dto/response/PartyResponse.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/dto/response/PartyResponse.java
@@ -1,0 +1,39 @@
+package com.geoparty.spring_boot.domain.party.dto.response;
+
+import com.geoparty.spring_boot.domain.member.entity.Member;
+import com.geoparty.spring_boot.domain.organization.entity.Organization;
+import com.geoparty.spring_boot.domain.party.entity.Party;
+import com.geoparty.spring_boot.domain.party.entity.PartyType;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PartyResponse {
+    private String title;
+    private String imgUrl;
+    private LocalDateTime payDate;
+    private Integer totalPoint;
+
+    @Builder
+    public PartyResponse(String title, String imgUrl, LocalDateTime payDate, Integer totalPoint) {
+        this.title = title;
+        this.imgUrl = imgUrl;
+        this.payDate = payDate;
+        this.totalPoint = totalPoint;
+    }
+
+    public static PartyResponse from(Party party){
+        return PartyResponse.builder()
+                .title(party.getTitle())
+                .imgUrl(party.getImgUrl())
+                .payDate(party.getPayDate())
+                .totalPoint(party.getTotalPoint())
+                .build();
+    }
+}

--- a/src/main/java/com/geoparty/spring_boot/domain/party/entity/Party.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/entity/Party.java
@@ -28,18 +28,21 @@ public class Party extends AuditingFields {
     @Column(nullable = false)
     private String intro;
 
-    private String imgUrl;
+//    private String imgUrl;
 
     private LocalDateTime payDate;
 
     @Column(nullable = false)
-    private Integer totalPoint; // 실제 모인 금액
+    private Integer totalPoint; // 실제 모인 포인트
 
     @Column(nullable = false)
-    private Integer targetPoint; // 목표 금액
+    private Integer targetPoint; // 후원 목표 포인트
 
     @Column(nullable = false)
-    private Integer pointPerPerson; // 1인당 후원 금액
+    private Integer pointPerPerson; // 1인당 후원 포인트
+
+    @Column(nullable = false)
+    private Integer count; // 파티 멤버 수
 
     private Integer duration; // 결제 지속 개월수
 
@@ -55,13 +58,13 @@ public class Party extends AuditingFields {
     private Organization organization;
 
     @Builder
-    public Party(String title, String intro, String imgUrl, Integer totalPoint, Integer targetPoint, Integer pointPerPerson, Integer duration, PartyType status, Member host, Organization organization) {
+    public Party(String title, String intro, Integer totalPoint, Integer targetPoint, Integer pointPerPerson, Integer count, Integer duration, PartyType status, Member host, Organization organization) {
         this.title = title;
         this.intro = intro;
-        this.imgUrl = imgUrl;
         this.totalPoint = 0;
         this.targetPoint = targetPoint;
         this.pointPerPerson = pointPerPerson;
+        this.count = count;
         this.duration = 0;
         this.status = PENDING;
         this.host = host;

--- a/src/main/java/com/geoparty/spring_boot/domain/party/entity/Party.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/entity/Party.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+import static com.geoparty.spring_boot.domain.party.entity.PartyType.PENDING;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,10 +28,23 @@ public class Party extends AuditingFields {
     @Column(nullable = false)
     private String intro;
 
-    private LocalDateTime pay_date;
+    private String imgUrl;
+
+    private LocalDateTime payDate;
 
     @Column(nullable = false)
-    private Integer total_point;
+    private Integer totalPoint; // 실제 모인 금액
+
+    @Column(nullable = false)
+    private Integer targetPoint; // 실제 모인 금액
+
+    @Column(nullable = false)
+    private Integer pointPerPerson;
+
+    private Integer duration;
+
+    @Enumerated(EnumType.STRING)
+    private PartyType status;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "host_id", nullable = false)
@@ -40,10 +55,16 @@ public class Party extends AuditingFields {
     private Organization organization;
 
     @Builder
-    public Party(String title, String intro, Integer total_point, Member host, Organization organization) {
+
+    public Party(String title, String intro, String imgUrl, Integer totalPoint, Integer targetPoint, Integer pointPerPerson, Integer duration, PartyType status, Member host, Organization organization) {
         this.title = title;
         this.intro = intro;
-        this.total_point = 0;
+        this.imgUrl = imgUrl;
+        this.totalPoint = 0;
+        this.targetPoint = targetPoint;
+        this.pointPerPerson = pointPerPerson;
+        this.duration = 0;
+        this.status = PENDING;
         this.host = host;
         this.organization = organization;
     }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/entity/Party.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/entity/Party.java
@@ -41,7 +41,7 @@ public class Party extends AuditingFields {
     @Column(nullable = false)
     private Integer pointPerPerson; // 1인당 후원 금액
 
-    private Integer duration; // 결제 지속 금액
+    private Integer duration; // 결제 지속 개월수
 
     @Enumerated(EnumType.STRING)
     private PartyType status;

--- a/src/main/java/com/geoparty/spring_boot/domain/party/entity/Party.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/entity/Party.java
@@ -36,12 +36,12 @@ public class Party extends AuditingFields {
     private Integer totalPoint; // 실제 모인 금액
 
     @Column(nullable = false)
-    private Integer targetPoint; // 실제 모인 금액
+    private Integer targetPoint; // 목표 금액
 
     @Column(nullable = false)
-    private Integer pointPerPerson;
+    private Integer pointPerPerson; // 1인당 후원 금액
 
-    private Integer duration;
+    private Integer duration; // 결제 지속 금액
 
     @Enumerated(EnumType.STRING)
     private PartyType status;
@@ -55,7 +55,6 @@ public class Party extends AuditingFields {
     private Organization organization;
 
     @Builder
-
     public Party(String title, String intro, String imgUrl, Integer totalPoint, Integer targetPoint, Integer pointPerPerson, Integer duration, PartyType status, Member host, Organization organization) {
         this.title = title;
         this.intro = intro;

--- a/src/main/java/com/geoparty/spring_boot/domain/party/entity/PartyType.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/entity/PartyType.java
@@ -1,0 +1,16 @@
+package com.geoparty.spring_boot.domain.party.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum PartyType {
+    PENDING("대기중"),
+    PROGRESS("정기 결제 시작"),
+    HALTED("정기 결제 중단");
+
+    private final String value;
+
+    PartyType(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/geoparty/spring_boot/domain/party/entity/UserParty.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/entity/UserParty.java
@@ -1,0 +1,34 @@
+package com.geoparty.spring_boot.domain.party.entity;
+
+import com.geoparty.spring_boot.domain.member.entity.Member;
+import com.geoparty.spring_boot.domain.organization.entity.Organization;
+import com.geoparty.spring_boot.global.domain.AuditingFields;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserParty extends AuditingFields {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_party_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "party_id", nullable = false)
+    private Party party;
+
+    @Builder
+    public UserParty(Member member, Party party) {
+        this.member = member;
+        this.party = party;
+    }
+}

--- a/src/main/java/com/geoparty/spring_boot/domain/party/entity/UserParty.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/entity/UserParty.java
@@ -19,7 +19,7 @@ public class UserParty extends AuditingFields {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/geoparty/spring_boot/domain/party/repository/PartyRepository.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/repository/PartyRepository.java
@@ -1,7 +1,11 @@
 package com.geoparty.spring_boot.domain.party.repository;
 
+import com.geoparty.spring_boot.domain.organization.entity.Organization;
 import com.geoparty.spring_boot.domain.party.entity.Party;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PartyRepository extends JpaRepository<Party, Long> {
+    List<Party> findByOrganization(Organization organizationId);
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/repository/PartyRepository.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/repository/PartyRepository.java
@@ -3,9 +3,15 @@ package com.geoparty.spring_boot.domain.party.repository;
 import com.geoparty.spring_boot.domain.organization.entity.Organization;
 import com.geoparty.spring_boot.domain.party.entity.Party;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface PartyRepository extends JpaRepository<Party, Long> {
     List<Party> findByOrganization(Organization organizationId);
+    @Query("SELECT p FROM Party p " +
+                    "JOIN FETCH p.organization " +
+                    "WHERE p.title LIKE %:title%")
+    List<Party> findByTitle(@Param("title") String title);
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/repository/UserPartyRepository.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/repository/UserPartyRepository.java
@@ -1,0 +1,7 @@
+package com.geoparty.spring_boot.domain.party.repository;
+
+import com.geoparty.spring_boot.domain.party.entity.UserParty;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPartyRepository extends JpaRepository<UserParty, Long> {
+}

--- a/src/main/java/com/geoparty/spring_boot/domain/party/repository/UserPartyRepository.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/repository/UserPartyRepository.java
@@ -1,5 +1,6 @@
 package com.geoparty.spring_boot.domain.party.repository;
 
+import com.geoparty.spring_boot.domain.member.entity.Member;
 import com.geoparty.spring_boot.domain.party.entity.Party;
 import com.geoparty.spring_boot.domain.party.entity.UserParty;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,8 +10,8 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface UserPartyRepository extends JpaRepository<UserParty, Long> {
-    @Query("SELECT up.party FROM UserParty up "
+    @Query("SELECT up FROM UserParty up "
             + "JOIN FETCH up.party "
-            + "WHERE up.member.userId = :userId")
-    List<Party> findPartiesByUserId(@Param("userId") Integer userId);
+            + "WHERE up.member = :member")
+    List<UserParty> findUserPartiesByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/repository/UserPartyRepository.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/repository/UserPartyRepository.java
@@ -10,8 +10,9 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface UserPartyRepository extends JpaRepository<UserParty, Long> {
-    @Query("SELECT up FROM UserParty up "
-            + "JOIN FETCH up.party "
-            + "WHERE up.member = :member")
+    @Query("SELECT up FROM UserParty up " +
+            "JOIN FETCH up.party p " +
+            "JOIN FETCH p.organization " +
+            "WHERE up.member = :member")
     List<UserParty> findUserPartiesByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/repository/UserPartyRepository.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/repository/UserPartyRepository.java
@@ -1,7 +1,16 @@
 package com.geoparty.spring_boot.domain.party.repository;
 
+import com.geoparty.spring_boot.domain.party.entity.Party;
 import com.geoparty.spring_boot.domain.party.entity.UserParty;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface UserPartyRepository extends JpaRepository<UserParty, Long> {
+    @Query("SELECT up.party FROM UserParty up "
+            + "JOIN FETCH up.party "
+            + "WHERE up.member.userId = :userId")
+    List<Party> findPartiesByUserId(@Param("userId") Integer userId);
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +31,6 @@ public class PartyService {
     @Transactional
     public void createParty(PartyRequest request, Member user) {
 //        validMember(user);
-
         String imgUrl = "환경 단체 이미지 url"; // to-do: 환경 단체 이미지 url로 변경
         Party party = request.toEntity(imgUrl, user);
         partyRepository.save(party);
@@ -50,9 +50,11 @@ public class PartyService {
         userPartyRepository.save(userParty);
     }
 
-//    public PartyResponse getParty(Member loginMember) {
-////        validMember(loginMember);
-//        List<Party> parties = partyRepository.findEmailsByProjectId(projectId);
-//        return ProjectResponse.from(emails);
-//    }
+    public List<PartyResponse> getParties(Member loginMember) {
+//        validMember(loginMember);
+        List<Party> parties = userPartyRepository.findPartiesByUserId(loginMember.getUserId());
+        return parties.stream()
+                .map(party -> PartyResponse.from(party))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
@@ -3,9 +3,12 @@ package com.geoparty.spring_boot.domain.party.service;
 import com.geoparty.spring_boot.domain.member.entity.Member;
 import com.geoparty.spring_boot.domain.member.repository.MemberRepository;
 import com.geoparty.spring_boot.domain.party.dto.request.PartyRequest;
+import com.geoparty.spring_boot.domain.party.dto.response.PartyResponse;
 import com.geoparty.spring_boot.domain.party.entity.Party;
+import com.geoparty.spring_boot.domain.party.entity.UserParty;
 import com.geoparty.spring_boot.domain.party.repository.PartyRepository;
 import com.geoparty.spring_boot.domain.member.entity.Member;
+import com.geoparty.spring_boot.domain.party.repository.UserPartyRepository;
 import com.geoparty.spring_boot.global.exception.BaseException;
 import com.geoparty.spring_boot.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -22,14 +25,34 @@ public class PartyService {
 
     private final PartyRepository partyRepository;
     private final MemberRepository memberRepository;
+    private final UserPartyRepository userPartyRepository;
 
     @Transactional
     public void createParty(PartyRequest request, Member user) {
-//        Member loginUser = memberRepository.findUserByUserId(user.getUserId())
-//                .orElseThrow(() -> new BaseException(ErrorCode.MEMBER_NOT_FOUND));
-        
+//        validMember(user);
+
         String imgUrl = "환경 단체 이미지 url"; // to-do: 환경 단체 이미지 url로 변경
         Party party = request.toEntity(imgUrl, user);
         partyRepository.save(party);
+        createUserParty(user, party);
     }
+
+    public void validMember(Member member){
+        Member loginUser = memberRepository.findUserByUserId(member.getUserId())
+                .orElseThrow(() -> new BaseException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    public void createUserParty(Member member, Party party) {
+        UserParty userParty = UserParty.builder()
+                .member(member)
+                .party(party)
+                .build();
+        userPartyRepository.save(userParty);
+    }
+
+//    public PartyResponse getParty(Member loginMember) {
+////        validMember(loginMember);
+//        List<Party> parties = partyRepository.findEmailsByProjectId(projectId);
+//        return ProjectResponse.from(emails);
+//    }
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
@@ -1,10 +1,13 @@
 package com.geoparty.spring_boot.domain.party.service;
 
 import com.geoparty.spring_boot.domain.member.entity.Member;
+import com.geoparty.spring_boot.domain.member.repository.MemberRepository;
 import com.geoparty.spring_boot.domain.party.dto.request.PartyRequest;
 import com.geoparty.spring_boot.domain.party.entity.Party;
 import com.geoparty.spring_boot.domain.party.repository.PartyRepository;
 import com.geoparty.spring_boot.domain.member.entity.Member;
+import com.geoparty.spring_boot.global.exception.BaseException;
+import com.geoparty.spring_boot.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,10 +21,15 @@ import java.util.List;
 public class PartyService {
 
     private final PartyRepository partyRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public void createParty(PartyRequest request, Member user) {
-        Party party = request.toEntity();
+//        Member loginUser = memberRepository.findUserByUserId(user.getUserId())
+//                .orElseThrow(() -> new BaseException(ErrorCode.MEMBER_NOT_FOUND));
+        
+        String imgUrl = "환경 단체 이미지 url"; // to-do: 환경 단체 이미지 url로 변경
+        Party party = request.toEntity(imgUrl, user);
         partyRepository.save(party);
     }
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
@@ -67,12 +67,19 @@ public class PartyService {
                 .collect(Collectors.toList());
     }
 
-    public List<PartyResponse> getParties(Long organizationId) {
+    public List<PartyResponse> getPartiesByOrganization(Long organizationId) {
         Organization organization = organizationRepository.findById(organizationId)
                 .orElseThrow(() -> new BaseException(ErrorCode.ORGANIZATION_NOT_FOUND));
         List<Party> parties = partyRepository.findByOrganization(organization);
         return parties.stream()
                 .map(party -> PartyResponse.from(party, organization))
+                .collect(Collectors.toList());
+    }
+
+    public List<PartyResponse> getPartiesByName(String partyName) {
+        List<Party> parties = partyRepository.findByTitle(partyName);
+        return parties.stream()
+                .map(party -> PartyResponse.from(party, party.getOrganization()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
@@ -2,6 +2,8 @@ package com.geoparty.spring_boot.domain.party.service;
 
 import com.geoparty.spring_boot.domain.member.entity.Member;
 import com.geoparty.spring_boot.domain.member.repository.MemberRepository;
+import com.geoparty.spring_boot.domain.organization.entity.Organization;
+import com.geoparty.spring_boot.domain.organization.repository.OrganizationRepository;
 import com.geoparty.spring_boot.domain.party.dto.request.PartyRequest;
 import com.geoparty.spring_boot.domain.party.dto.response.PartyResponse;
 import com.geoparty.spring_boot.domain.party.entity.Party;
@@ -27,6 +29,7 @@ public class PartyService {
     private final PartyRepository partyRepository;
     private final MemberRepository memberRepository;
     private final UserPartyRepository userPartyRepository;
+    private final OrganizationRepository organizationRepository;
 
     @Transactional
     public void createParty(PartyRequest request, Member user) {
@@ -50,11 +53,20 @@ public class PartyService {
         userPartyRepository.save(userParty);
     }
 
-    public List<PartyResponse> getParties(Member loginMember) {
+    public List<PartyResponse> getHomeParties(Member loginMember) {
 //        validMember(loginMember);
         List<UserParty> parties = userPartyRepository.findUserPartiesByMember(loginMember);
         return parties.stream()
-                .map(userParty -> PartyResponse.from(userParty.getParty()))
+                .map(userParty -> PartyResponse.from(userParty.getParty(), userParty.getParty().getOrganization()))
+                .collect(Collectors.toList());
+    }
+
+    public List<PartyResponse> getParties(Long organizationId) {
+        Organization organization = organizationRepository.findById(organizationId)
+                .orElseThrow(() -> new BaseException(ErrorCode.ORGANIZATION_NOT_FOUND));
+        List<Party> parties = partyRepository.findByOrganization(organization);
+        return parties.stream()
+                .map(party -> PartyResponse.from(party, organization))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
@@ -34,10 +34,16 @@ public class PartyService {
     @Transactional
     public void createParty(PartyRequest request, Member user) {
 //        validMember(user);
-        String imgUrl = "환경 단체 이미지 url"; // to-do: 환경 단체 이미지 url로 변경
-        Party party = request.toEntity(imgUrl, user);
+        Party party = request.toEntity(user, countPartyMembers(request.getTargetPoint(), request.getPointPerPerson()));
         partyRepository.save(party);
         createUserParty(user, party);
+    }
+
+    public Integer countPartyMembers(Integer targetPoint, Integer pointPerPerson){
+        if (pointPerPerson == 0) {
+            throw new IllegalArgumentException("1인당 후원 금액은 0이 될 수 없습니다.");
+        }
+        return (int) Math.ceil((double) targetPoint / pointPerPerson);
     }
 
     public void validMember(Member member){

--- a/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
@@ -52,9 +52,9 @@ public class PartyService {
 
     public List<PartyResponse> getParties(Member loginMember) {
 //        validMember(loginMember);
-        List<Party> parties = userPartyRepository.findPartiesByUserId(loginMember.getUserId());
+        List<UserParty> parties = userPartyRepository.findUserPartiesByMember(loginMember);
         return parties.stream()
-                .map(party -> PartyResponse.from(party))
+                .map(userParty -> PartyResponse.from(userParty.getParty()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/geoparty/spring_boot/global/exception/ErrorCode.java
+++ b/src/main/java/com/geoparty/spring_boot/global/exception/ErrorCode.java
@@ -2,6 +2,7 @@ package com.geoparty.spring_boot.global.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 @Getter
@@ -13,7 +14,9 @@ public enum ErrorCode {
     NOT_PRIVIEGED(403, "접근 권한이 없습니다."),
     NOT_FOUND_DATA(404, "데이터를 찾지 못했습니다."),
     NOT_FOUND(404, "페이지를 찾지 못했습니다."),
-    NOT_ENOUGH_MILEAGE(403,"마일리지가 부족합니다." );
+    NOT_ENOUGH_MILEAGE(403,"마일리지가 부족합니다." ),
+
+    MEMBER_NOT_FOUND(404, "존재하지 않는 유저입니다.");
 
 
     private final int errorCode;

--- a/src/main/java/com/geoparty/spring_boot/global/exception/ErrorCode.java
+++ b/src/main/java/com/geoparty/spring_boot/global/exception/ErrorCode.java
@@ -16,7 +16,8 @@ public enum ErrorCode {
     NOT_FOUND(404, "페이지를 찾지 못했습니다."),
     NOT_ENOUGH_MILEAGE(403,"마일리지가 부족합니다." ),
 
-    MEMBER_NOT_FOUND(404, "존재하지 않는 유저입니다.");
+    MEMBER_NOT_FOUND(404, "존재하지 않는 유저입니다."),
+    ORGANIZATION_NOT_FOUND(404, "존재하지 않는 환경단체입니다.");
 
 
     private final int errorCode;

--- a/src/main/java/com/geoparty/spring_boot/security/config/SecurityConfig.java
+++ b/src/main/java/com/geoparty/spring_boot/security/config/SecurityConfig.java
@@ -42,6 +42,9 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                                 .requestMatchers(HttpMethod.GET,"/api/auth/refresh").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/api/auth/logout").permitAll()
+                                // api 테스트를 위한 임시 허용
+                                .requestMatchers(HttpMethod.GET,"/api/**").permitAll()
+                                .requestMatchers(HttpMethod.POST,"/api/**").permitAll()
                                 .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)  // Http 요청이 UsernamePasswordAuthenticationFilter 전에 JwtAuthenticationFilter
                 .build();


### PR DESCRIPTION
## 🖋️ merge 전 확인사항
- [x] merge할 브랜치가 main인지?
- [x] ERD 반영했는지?
- [x] API 명세서 반영했는지?

## 📕 구현한 기능
- 파티 생성 기능
- 파티 리스트 조회 기능(환경 단체에 따라, 이름으로 검색)
- 홈화면 하단 파티 리스트 조회 기능

## 📜 참고사항
- n+1 문제 방지를 위해 fetch join을 사용하였습니다. (https://developer-ping9.tistory.com/255)
- 파티 생성 시 로그인한 유저 정보 반환하는 기능 추가해주어야 합니다!