### PR TITLE
[FEAT] 파티 세부 정보 반환 기능 추가

### DIFF
--- a/src/main/java/com/geoparty/spring_boot/domain/party/controller/PartyController.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/controller/PartyController.java
@@ -3,6 +3,7 @@ package com.geoparty.spring_boot.domain.party.controller;
 import com.geoparty.spring_boot.domain.member.entity.Member;
 import com.geoparty.spring_boot.domain.member.repository.MemberRepository;
 import com.geoparty.spring_boot.domain.party.dto.request.PartyRequest;
+import com.geoparty.spring_boot.domain.party.dto.response.PartyDetailResponse;
 import com.geoparty.spring_boot.domain.party.dto.response.PartyResponse;
 import com.geoparty.spring_boot.domain.party.entity.Party;
 import com.geoparty.spring_boot.domain.party.service.PartyService;
@@ -60,5 +61,12 @@ public class PartyController {
             // 파티 이름에 따른 파티 조회
             return ResponseEntity.status(HttpStatus.OK).body(partyService.getPartiesByName(partyName));
         }
+    }
+
+    @GetMapping("/{party-id}")
+    @Operation(description = "파티 세부 정보를 반환한다")
+    public ResponseEntity<PartyDetailResponse> getPartyDetails(
+            @PathVariable(name = "party-id") Long partyId) {
+        return ResponseEntity.status(HttpStatus.OK).body(partyService.getPartyDetails(partyId));
     }
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/dto/response/PartyDetailResponse.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/dto/response/PartyDetailResponse.java
@@ -1,0 +1,37 @@
+package com.geoparty.spring_boot.domain.party.dto.response;
+
+import com.geoparty.spring_boot.domain.member.dto.MemberDto;
+import com.geoparty.spring_boot.domain.organization.entity.Organization;
+import com.geoparty.spring_boot.domain.party.entity.Party;
+import com.geoparty.spring_boot.domain.payment.dto.response.PaymentResponse;
+import com.geoparty.spring_boot.domain.payment.entity.Payment;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PartyDetailResponse {
+
+    private PartyResponse partyResponse;
+    private List<MemberDto> members;
+    private List<PaymentResponse> payments;
+
+    @Builder
+    public PartyDetailResponse(PartyResponse partyResponse, List<MemberDto> members, List<PaymentResponse> payments) {
+        this.partyResponse = partyResponse;
+        this.members = members;
+        this.payments = payments;
+    }
+
+    public static PartyDetailResponse from(PartyResponse partyResponse, List<MemberDto> members, List<PaymentResponse> payments) {
+        return PartyDetailResponse.builder()
+                .partyResponse(partyResponse)
+                .members(members)
+                .payments(payments)
+                .build();
+    }
+}

--- a/src/main/java/com/geoparty/spring_boot/domain/party/dto/response/PartyResponse.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/dto/response/PartyResponse.java
@@ -72,6 +72,7 @@ public class PartyResponse {
                 .title(party.getTitle())
                 .intro(party.getIntro())
                 .payDate(party.getPayDate())
+                .startDate(party.getCreatedAt())
                 .duration(party.getDuration())
                 .targetPoint(party.getTargetPoint())
                 .totalPoint(party.getTotalPoint())

--- a/src/main/java/com/geoparty/spring_boot/domain/party/dto/response/PartyResponse.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/dto/response/PartyResponse.java
@@ -29,6 +29,9 @@ public class PartyResponse {
     @Schema(description = "파티 소개")
     private String intro;
 
+    @Schema(description = "파티 시작 날짜")
+    private LocalDateTime startDate;
+
     @Schema(description = "결제 예정 날짜")
     private LocalDateTime payDate;
 
@@ -48,11 +51,12 @@ public class PartyResponse {
     private PartyType status;
 
     @Builder
-    public PartyResponse(String organization, String imgUrl, String title, String intro, LocalDateTime payDate, Integer duration, Integer targetPoint, Integer totalPoint, Integer pointPerPerson, PartyType status) {
+    public PartyResponse(String organization, String imgUrl, String title, String intro, LocalDateTime startDate, LocalDateTime payDate, Integer duration, Integer targetPoint, Integer totalPoint, Integer pointPerPerson, PartyType status) {
         this.organization = organization;
         this.imgUrl = imgUrl;
         this.title = title;
         this.intro = intro;
+        this.startDate = startDate;
         this.payDate = payDate;
         this.duration = duration;
         this.targetPoint = targetPoint;

--- a/src/main/java/com/geoparty/spring_boot/domain/party/repository/UserPartyRepository.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/repository/UserPartyRepository.java
@@ -15,4 +15,10 @@ public interface UserPartyRepository extends JpaRepository<UserParty, Long> {
             "JOIN FETCH p.organization " +
             "WHERE up.member = :member")
     List<UserParty> findUserPartiesByMember(@Param("member") Member member);
+
+    @Query("SELECT up FROM UserParty up " +
+            "JOIN FETCH up.party p " +
+            "JOIN FETCH up.member m " +
+            "WHERE p = :party")
+    List<UserParty> findUserPartiesByParty(@Param("party") Party party);
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/party/service/PartyService.java
@@ -1,16 +1,21 @@
 package com.geoparty.spring_boot.domain.party.service;
 
+import com.geoparty.spring_boot.domain.member.dto.MemberDto;
 import com.geoparty.spring_boot.domain.member.entity.Member;
 import com.geoparty.spring_boot.domain.member.repository.MemberRepository;
 import com.geoparty.spring_boot.domain.organization.entity.Organization;
 import com.geoparty.spring_boot.domain.organization.repository.OrganizationRepository;
 import com.geoparty.spring_boot.domain.party.dto.request.PartyRequest;
+import com.geoparty.spring_boot.domain.party.dto.response.PartyDetailResponse;
 import com.geoparty.spring_boot.domain.party.dto.response.PartyResponse;
 import com.geoparty.spring_boot.domain.party.entity.Party;
 import com.geoparty.spring_boot.domain.party.entity.UserParty;
 import com.geoparty.spring_boot.domain.party.repository.PartyRepository;
 import com.geoparty.spring_boot.domain.member.entity.Member;
 import com.geoparty.spring_boot.domain.party.repository.UserPartyRepository;
+import com.geoparty.spring_boot.domain.payment.dto.response.PaymentResponse;
+import com.geoparty.spring_boot.domain.payment.entity.Payment;
+import com.geoparty.spring_boot.domain.payment.repository.PaymentRepository;
 import com.geoparty.spring_boot.global.exception.BaseException;
 import com.geoparty.spring_boot.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +35,7 @@ public class PartyService {
     private final MemberRepository memberRepository;
     private final UserPartyRepository userPartyRepository;
     private final OrganizationRepository organizationRepository;
+    private final PaymentRepository paymentRepository;
 
     @Transactional
     public void createParty(PartyRequest request, Member user) {
@@ -80,6 +86,26 @@ public class PartyService {
         List<Party> parties = partyRepository.findByTitle(partyName);
         return parties.stream()
                 .map(party -> PartyResponse.from(party, party.getOrganization()))
+                .collect(Collectors.toList());
+    }
+
+    public PartyDetailResponse getPartyDetails(Long partyId) {
+        Party party = partyRepository.findById(partyId)
+                .orElseThrow(() -> new BaseException(ErrorCode.PARTY_NOT_FOUND));
+        return PartyDetailResponse.from(PartyResponse.from(party, party.getOrganization()), toMemberResponse(party), toPaymentResponse(party));
+    }
+
+    public List<MemberDto> toMemberResponse(Party party) {
+        List<UserParty> members = userPartyRepository.findUserPartiesByParty(party);
+        return members.stream()
+                .map(userParty -> MemberDto.from(userParty.getMember()))
+                .collect(Collectors.toList());
+    }
+
+    public List<PaymentResponse> toPaymentResponse(Party party) {
+        List<Payment> payments = paymentRepository.findAllByPartyId(party.getId());
+        return payments.stream()
+                .map(payment -> PaymentResponse.from(payment))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/payment/dto/response/PaymentResponse.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/payment/dto/response/PaymentResponse.java
@@ -23,7 +23,7 @@ public class PaymentResponse {
     public static PaymentResponse from(Payment payment){
         return PaymentResponse.builder()
                 .amount(payment.getAmount())
-                .date(payment.getDate())
+                .date(payment.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/payment/dto/response/PaymentResponse.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/payment/dto/response/PaymentResponse.java
@@ -1,0 +1,29 @@
+package com.geoparty.spring_boot.domain.payment.dto.response;
+
+import com.geoparty.spring_boot.domain.payment.entity.Payment;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class PaymentResponse {
+
+    private Integer amount;
+    private LocalDateTime date;
+
+    @Builder
+    public PaymentResponse(Integer amount, LocalDateTime date) {
+        this.amount = amount;
+        this.date = date;
+    }
+
+    public static PaymentResponse from(Payment payment){
+        return PaymentResponse.builder()
+                .amount(payment.getAmount())
+                .date(payment.getDate())
+                .build();
+    }
+}

--- a/src/main/java/com/geoparty/spring_boot/domain/payment/entity/Payment.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/payment/entity/Payment.java
@@ -1,0 +1,31 @@
+package com.geoparty.spring_boot.domain.payment.entity;
+
+import com.geoparty.spring_boot.domain.organization.entity.Organization;
+import com.geoparty.spring_boot.domain.party.entity.Party;
+import com.geoparty.spring_boot.global.domain.AuditingFields;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends AuditingFields {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "party_id", nullable = false)
+    private Party party;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    @Column(nullable = false)
+    private LocalDateTime date;
+}

--- a/src/main/java/com/geoparty/spring_boot/domain/payment/entity/Payment.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/payment/entity/Payment.java
@@ -25,7 +25,4 @@ public class Payment extends AuditingFields {
 
     @Column(nullable = false)
     private Integer amount;
-
-    @Column(nullable = false)
-    private LocalDateTime date;
 }

--- a/src/main/java/com/geoparty/spring_boot/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/geoparty/spring_boot/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,10 @@
+package com.geoparty.spring_boot.domain.payment.repository;
+
+import com.geoparty.spring_boot.domain.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    List<Payment> findAllByPartyId(Long partyId);
+}

--- a/src/main/java/com/geoparty/spring_boot/global/exception/ErrorCode.java
+++ b/src/main/java/com/geoparty/spring_boot/global/exception/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode {
     NOT_ENOUGH_MILEAGE(403,"마일리지가 부족합니다." ),
 
     MEMBER_NOT_FOUND(404, "존재하지 않는 유저입니다."),
-    ORGANIZATION_NOT_FOUND(404, "존재하지 않는 환경단체입니다.");
+    ORGANIZATION_NOT_FOUND(404, "존재하지 않는 환경단체입니다."),
+    PARTY_NOT_FOUND(404, "존재하지 않는 파티입니다");
 
 
     private final int errorCode;


### PR DESCRIPTION
## 🖋️ merge 전 확인사항
- [x] merge할 브랜치가 main인지?
- [x] ERD 반영했는지?
- [x] API 명세서 반영했는지?

## 📕 구현한 기능
- 파티 세부 정보 반환 기능
- 결제정보(Payment) 엔티티 생성

## 📜 참고사항
- Authorization 없이 API 테스트 하고 싶으면 WebConfig 삭제하고 진행하기